### PR TITLE
Use descriptive names in plot controls param select

### DIFF
--- a/edr_explorer/explorer.py
+++ b/edr_explorer/explorer.py
@@ -149,7 +149,7 @@ class EDRExplorer(param.Parameterized):
         self.pc_times.value = plot_control_times[0]
 
         plot_control_params = list(param_names)
-        self.pc_params.options = plot_control_params
+        self.pc_params.options = list(filter(lambda o: o[1] in plot_control_params, self.datasets.options))
         self.pc_params.value = plot_control_params[0]
 
         self._enable_plot_controls()

--- a/edr_explorer/interface.py
+++ b/edr_explorer/interface.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from .lookup import CRS_LOOKUP, TRS_LOOKUP
 
+
 class EDRInterface(object):
     """
     An interface to an EDR Server that can navigate the query structure to


### PR DESCRIPTION
The parameter selector for the plot controls now uses the same friendly descriptions as the Datasets query selector, which makes for a more navigable interface.