### PR TITLE
Add request error handling

### DIFF
--- a/edr_explorer/data.py
+++ b/edr_explorer/data.py
@@ -126,7 +126,7 @@ class DataHandler(object):
         template_dict = {k: self.coords[k].index(v) for k, v in coords_dict.items()}
         url_template = param_info["tileSets"][0]["urlTemplate"]
         url = url_template.format(**template_dict)
-        r = get_request(url)
+        r, status_code, errors = get_request(url)
 
         if param_type == "TiledNdArray":
             array = np.array(r["values"], dtype=r['dataType']).reshape(r["shape"])

--- a/edr_explorer/util.py
+++ b/edr_explorer/util.py
@@ -2,8 +2,21 @@ import requests
 
 
 def get_request(uri):
-    r = requests.get(uri)
-    return r.json()
+    """
+    Make an HTTP GET request to the (EDR) Server at `uri`.
+
+    """
+    response = None
+    status_code = None
+    errors = None
+    try:
+        r = requests.get(uri)
+    except Exception as e:
+        errors = e.__class__.__name__
+    else:
+        status_code = r.status_code
+        response = r.json()
+    return response, status_code, errors
 
 
 def dict_list_search(l, keys, value):


### PR DESCRIPTION
Add error handling for requests to the EDR Server. This allows errors to be handled gracefully so that the explorer dashboard does not fail if a request returns an error. This includes:
* catching errors when making the get request
* the `Interface` handling failed requests
* the dashboard showing error boxes when a request fails

Still to do:
- [ ] `DataHandler` error handling and propagation
- [ ] styling of dashboard error boxes / not displaying properly
- [ ] clear error boxes on dashboard once error is solved