### PR TITLE
Provide suggested colours and levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,22 @@ This can be used either in a notebook or in a Python script that can be served b
 panel serve --show run.py
 ```
 
+### Tips and tricks
+
+#### Plot options
+
+The explorer interface sets a limited number of options for plotting the selected data, specifically the colormap of the plotted data and its alpha (transparency). The values for these options are publically accessible, and can be customised for a specifed interface instance as follows:
+
+```python
+explorer.cmap = "inferno"
+explorer.alpha = 0.75
+```
+
+This assumes that you have set up an explorer interface as per the Python code above. The colormap can be
+set as any valid reference to a colormap from [matplotlib](https://matplotlib.org/stable/gallery/color/colormap_reference.html) or [colorcet](https://colorcet.holoviz.org/), including as simple string names of the colormap, as shown here.
+
+#### Pre-populate the EDR Server address
+
 You can also pass the URI for a running EDR Server to the explorer interface when you instantiate it. For example:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ explorer.cmap = "inferno"
 explorer.alpha = 0.75
 ```
 
-This assumes that you have set up an explorer interface as per the Python code above. The colormap can be
-set as any valid reference to a colormap from [matplotlib](https://matplotlib.org/stable/gallery/color/colormap_reference.html) or [colorcet](https://colorcet.holoviz.org/), including as simple string names of the colormap, as shown here.
+This assumes that you have set up an explorer interface called `explorer` as per the Python code above. The colormap can be set as any valid reference to a colormap from [matplotlib](https://matplotlib.org/stable/gallery/color/colormap_reference.html) or [colorcet](https://colorcet.holoviz.org/), including as simple string names of the colormap, as shown here.
 
 #### Pre-populate the EDR Server address
 

--- a/edr_explorer/data.py
+++ b/edr_explorer/data.py
@@ -167,6 +167,7 @@ class DataHandler(object):
         return result
 
     def get_colours(self, param_name):
+        """Get a single colours reference from `self.colours`, or populate it if not present."""
         if self.colours.get(param_name) is not None:
             result = self.colours[param_name]
         else:
@@ -191,6 +192,12 @@ class DataHandler(object):
         return param_name, coords_dict
 
     def _build_custom_cmap(self, param_name):
+        """
+        Retrieve categorised colour and level information from the data JSON, if present.
+
+        If no such information is present, the result will be `None`.
+        
+        """
         try:
             categories = self.data_json["parameters"][param_name]["categoryEncoding"]
         except KeyError:

--- a/edr_explorer/data.py
+++ b/edr_explorer/data.py
@@ -25,6 +25,7 @@ class DataHandler(object):
         """
         self.data_json = data_json
         self.cache = {}
+        self.colours = {}
 
         self._errors = None
         self._coords = None
@@ -114,10 +115,15 @@ class DataHandler(object):
 
     def _build_geoviews(self, array, param_name):
         """Construct a GeoViews Dataset object from an nD array data response."""
+        colours = self.get_colours(param_name)
+        if colours is not None:
+            data = np.ma.masked_less(array[0], colours["vmin"])
+        else:
+            data = np.ma.masked_invalid(array[0])
         ds = HVDataset(
-            data=(self.coords["y"], self.coords["x"], np.ma.masked_invalid(array[0])),
+            data=(self.coords["y"], self.coords["x"], data),
             kdims=["latitude", "longitude"],
-            vdims=param_name
+            vdims=param_name,
         )
         return ds.to(GVDataset, crs=self.crs)
 
@@ -160,6 +166,14 @@ class DataHandler(object):
             self.cache[key] = result
         return result
 
+    def get_colours(self, param_name):
+        if self.colours.get(param_name) is not None:
+            result = self.colours[param_name]
+        else:
+            result = self._build_custom_cmap(param_name)
+            self.colours[param_name] = result
+        return result
+
     def make_key(self, param, coords_dict):
         """Define the standard form for keys in the data cache."""
         coord_str = ','.join([f"{k}={coords_dict[k]}" for k in sorted(coords_dict)])
@@ -175,6 +189,24 @@ class DataHandler(object):
         param_name = param.split("=")[1]
         coords_dict = {c.split("=")[0]: c.split("=")[1] for c in coords}
         return param_name, coords_dict
+
+    def _build_custom_cmap(self, param_name):
+        try:
+            categories = self.data_json["parameters"][param_name]["categoryEncoding"]
+        except KeyError:
+            result = None
+        else:
+            colours = list(categories.keys())
+            values = list(categories.values())
+            vmin, vmax = min(values), max(values)
+            high_value, = np.diff(values[-2:])
+            result = {
+                "colours": colours,
+                "values": values + [high_value],
+                "vmin": vmin,
+                "vmax": vmax
+            }
+        return result
 
     # def _prepare_json(self):
     #     param_names = list(self.data_json["parameters"].keys())

--- a/edr_explorer/explorer.py
+++ b/edr_explorer/explorer.py
@@ -56,6 +56,10 @@ class EDRExplorer(param.Parameterized):
 
         super().__init__()
 
+        # Public plot opts.
+        self.cmap = "viridis"
+        self.alpha = 0.85
+
         self._edr_interface = None
 
         self.connect_button.on_click(self._load_collections)
@@ -283,7 +287,7 @@ class EDRExplorer(param.Parameterized):
         showable = tiles
         if self._data_key != "":
             dataset = self.edr_interface.data_handler[self._data_key]
-            opts = {"cmap": "viridis", "alpha": 0.9}
+            opts = {"cmap": self.cmap, "alpha": self.alpha}
 
             colours = self.edr_interface.data_handler.get_colours(self.pc_params.value)
             if colours is not None:

--- a/edr_explorer/explorer.py
+++ b/edr_explorer/explorer.py
@@ -283,6 +283,12 @@ class EDRExplorer(param.Parameterized):
         showable = tiles
         if self._data_key != "":
             dataset = self.edr_interface.data_handler[self._data_key]
+            opts = {"cmap": "viridis", "alpha": 0.9}
+
+            colours = self.edr_interface.data_handler.get_colours(self.pc_params.value)
+            if colours is not None:
+                opts.update({"clim": (colours["vmin"], colours["vmax"])})
+
             error_box = "data_error_box"
             if self.edr_interface.data_handler.errors is None:
                 # Independent check to see if we can clear the data error box.
@@ -291,7 +297,7 @@ class EDRExplorer(param.Parameterized):
                 showable = tiles * dataset.to(
                     gv.Image,
                     ['longitude', 'latitude']
-                ).opts(cmap="viridis", alpha=0.75)
+                ).opts(**opts)
             elif self.edr_interface.data_handler.errors is not None:
                 self._populate_error_box(
                     error_box,

--- a/edr_explorer/explorer.py
+++ b/edr_explorer/explorer.py
@@ -28,6 +28,8 @@ class EDRExplorer(param.Parameterized):
     # Plot control widgets.
     pc_times = widgets.SelectionSlider(options=[""], description="Timestep", disabled=True)
     pc_params = widgets.Dropdown(options=[], description="Parameter", disabled=True)
+    cmap = param.String("viridis")
+    alpha = param.Magnitude(0.85)
 
     # Dataset reference.
     _data_key = param.String("")
@@ -55,10 +57,6 @@ class EDRExplorer(param.Parameterized):
             self.coll_uri.value = self.server_address
 
         super().__init__()
-
-        # Public plot opts.
-        self.cmap = "viridis"
-        self.alpha = 0.85
 
         self._edr_interface = None
 
@@ -280,7 +278,7 @@ class EDRExplorer(param.Parameterized):
         if param is not None and t not in (None, ""):
             self._data_key = self.edr_interface.data_handler.make_key(param, {"t": t})
 
-    @param.depends('_data_key')
+    @param.depends('_data_key', 'cmap', 'alpha')
     def plot(self):
         """Show data from a data request to the EDR Server on the plot."""
         tiles = gv.tile_sources.Wikipedia.opts(width=800, height=600)


### PR DESCRIPTION
Use suggested colours and levels from the EDR Server, if supplied, to render data on the plot. Users of the dashboard can choose whether to use these colours and levels for rendering plot data through plot-controlling checkboxes.

Closes #6. Supersedes #16.