### PR TITLE
Provide notebook access to dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ This can be used either in a notebook or in a Python script that can be served b
 panel serve --show run.py
 ```
 
+### Accessing the data
+
+You can request all the data described by ... from the EDR Server by clicking the `Get Dataset` button in the explorer interface. This will make the data represented by the current state of the select widgets in the explorer interface available in a common Python data format appropriate
+for the type of data. Note that currently the only formats supported for this are Iris `Cube` and `CubeList` objects.
+
+To access the data:
+
+```python
+explorer.dataset
+```
+
 ### Tips and tricks
 
 #### Plot options

--- a/edr_explorer/dataset.py
+++ b/edr_explorer/dataset.py
@@ -37,13 +37,6 @@ class IrisCubeDataset(_Dataset):
         points = [unit.date2num(dt) for dt in dts]
         return unit, points
 
-    # def _get_data(self):
-    #     data = self.data_handler.all_data[self.names]
-    #     subset_inds = [slice(None)] * len(self.data_handler.coords.keys())
-    #     for axis in self.data_handler.selection_axes:
-    #         axis_ind = self.data_handler.coords.keys().index(axis)
-    #     return data
-
     def build_coord(self, axis_name):
         values = self.data_handler.coords[axis_name]
 
@@ -80,8 +73,6 @@ class IrisCubeDataset(_Dataset):
             coord = self.build_coord(axis)
             dcad.append((coord, i))
 
-        # data = self._get_data()
-
         cube = Cube(
             self.data_handler.all_data[self.names],
             long_name=self.names,
@@ -111,7 +102,7 @@ def make_dataset(data_handler, names, to="iris"):
     if isinstance(names, str):
         names = [names]
 
-    n_params = len(names)  # XXX watch out for a string iterable!
+    n_params = len(names)
     if to == "iris":
         if n_params == 1:
             provider = IrisCubeDataset(data_handler, names[0])

--- a/edr_explorer/dataset.py
+++ b/edr_explorer/dataset.py
@@ -1,0 +1,107 @@
+import datetime
+
+import cartopy.crs as ccrs
+from cf_units import Unit
+from iris.coords import DimCoord
+from iris.coord_systems import GeogCS
+from iris.cube import Cube, CubeList
+import numpy as np
+
+from .lookup import (
+    HORIZONTAL_AXES_LOOKUP,
+    ISO_DATE_FMT_STR,
+    UNITS_LOOKUP,
+)
+
+
+class _Dataset(object):
+    def __init__(self, data_handler, names):
+        self.data_handler = data_handler
+        self.names = names
+
+    def build_dataset(self):
+        raise NotImplementedError
+
+
+class IrisCubeDataset(_Dataset):
+    def __init__(self, data_handler, name):
+        super().__init__(data_handler, name)
+
+    def _handle_time_coord(self, values):
+        epoch = "days since 1970-01-01"
+        calendar = self.data_handler.trs.lower()
+        units = Unit(epoch, calendar=calendar)
+
+        points = [datetime.datetime.strptime(s, ISO_DATE_FMT_STR) for s in values]
+        return units, points
+
+    def build_coord(self, axis_name):
+        values = self.data_handler.coords[axis_name]
+
+        if axis_name in HORIZONTAL_AXES_LOOKUP.keys():
+            crs = self.data_handler.crs
+            if isinstance(crs, ccrs.PlateCarree()):
+                ref_sys = GeogCS()
+            units = UNITS_LOOKUP[ref_sys]
+            points = np.array(values)
+        elif axis_name == "t":
+            ref_sys = None
+            units, points = self._handle_time_coord(values)
+        else:
+            ref_sys = None
+            units = None
+            points = np.array(values)
+
+        coord = DimCoord(
+            points,
+            long_name=axis_name,
+            units=units,
+            coord_system=ref_sys,
+        )
+        return coord
+
+    def build_dataset(self):
+        axes = self.data_handler.coords.keys()
+        dcad = []
+        for i, axis in enumerate(axes):
+            coord = self.build_coord(axis)
+            dcad.append(coord, i)
+
+        cube = Cube(
+            self.data_handler.all_data[self.name],
+            long_name=self.name,
+            units=self.data_handler.units[self.name].replace("/", " "),
+            dim_coords_and_dims=dcad,
+        )
+        return cube
+
+
+class IrisCubeListDataset(_Dataset):
+    def __init__(self, data_handler, names):
+        super().__init__(data_handler, names)
+
+    def build_dataset(self):
+        cubes = []
+        for name in self.names:
+            cube = IrisCubeDataset(self.data_handler, name).build_dataset()
+            cubes.append(cube)
+        return CubeList(cubes)
+
+
+def make_dataset(data_handler, names, to="iris"):
+    valid_handers = ["iris"]
+    if to not in valid_handers:
+        emsg = f"`to` must be one of: {','.join(valid_handers)!r}; got {to}."
+        raise ValueError(emsg)
+
+    n_params = len(names)  # XXX watch out for a string iterable!
+    if to == "iris":
+        if n_params == 1:
+            provider = IrisCubeDataset(data_handler, names)
+        elif n_params > 1:
+            provider = IrisCubeListDataset(data_handler, names)
+        else:
+            emsg = f"Number of parameters must be greater than or equal to 1, got {n_params}."
+            raise ValueError(emsg)
+
+    return provider.build_dataset()

--- a/edr_explorer/explorer.py
+++ b/edr_explorer/explorer.py
@@ -308,7 +308,7 @@ class EDRExplorer(param.Parameterized):
         # XXX somewhere we should check if the server supports `Cube` queries,
         #     and preferentially use that if available.
         from .dataset import make_dataset
-        dataset = make_dataset(self.edr_interface.data_handlers)
+        dataset = make_dataset(self.edr_interface.data_handlers, self.pc_params.value)
         self.dataset = dataset
 
     def _request_plot_data(self, _):

--- a/edr_explorer/explorer.py
+++ b/edr_explorer/explorer.py
@@ -308,7 +308,7 @@ class EDRExplorer(param.Parameterized):
         # XXX somewhere we should check if the server supports `Cube` queries,
         #     and preferentially use that if available.
         from .dataset import make_dataset
-        dataset = make_dataset(self.edr_interface.data_handlers, self.pc_params.value)
+        dataset = make_dataset(self.edr_interface.data_handler, self.pc_params.value)
         self.dataset = dataset
 
     def _request_plot_data(self, _):

--- a/edr_explorer/explorer.py
+++ b/edr_explorer/explorer.py
@@ -221,6 +221,7 @@ class EDRExplorer(param.Parameterized):
             box.value = False
             box.disabled = True
         self.submit_button.disabled = True
+        self.dataset_button.disabled = True
         self._populate_error_box("connect_error_box", "")
         self._populate_error_box("data_error_box", "")
 
@@ -251,6 +252,7 @@ class EDRExplorer(param.Parameterized):
         """Enable plot control widgets for updating the specific data shown on the plot."""
         for widget in self.pwlist:
             widget.disabled = False
+        self.dataset_button.disabled = False
         self._check_enable_checkboxes()
 
     def _populate_contents_callback(self, change):
@@ -303,7 +305,10 @@ class EDRExplorer(param.Parameterized):
         object (such as an Iris Cube).
 
         """
-        dataset = None
+        # XXX somewhere we should check if the server supports `Cube` queries,
+        #     and preferentially use that if available.
+        from .dataset import make_dataset
+        dataset = make_dataset(self.edr_interface.data_handlers)
         self.dataset = dataset
 
     def _request_plot_data(self, _):

--- a/edr_explorer/explorer.py
+++ b/edr_explorer/explorer.py
@@ -308,7 +308,12 @@ class EDRExplorer(param.Parameterized):
         # XXX somewhere we should check if the server supports `Cube` queries,
         #     and preferentially use that if available.
         from .dataset import make_dataset
-        dataset = make_dataset(self.edr_interface.data_handler, self.datasets.value)
+
+        collection_id = self.coll.value
+        params = self.edr_interface.get_collection_parameters(collection_id)
+        keys = self.datasets.value
+        names_dict = {k: v["label"] for k, v in params.items() if k in keys}
+        dataset = make_dataset(self.edr_interface.data_handler, names_dict)
         self.dataset = dataset
 
     def _request_plot_data(self, _):

--- a/edr_explorer/explorer.py
+++ b/edr_explorer/explorer.py
@@ -308,7 +308,7 @@ class EDRExplorer(param.Parameterized):
         # XXX somewhere we should check if the server supports `Cube` queries,
         #     and preferentially use that if available.
         from .dataset import make_dataset
-        dataset = make_dataset(self.edr_interface.data_handler, self.pc_params.value)
+        dataset = make_dataset(self.edr_interface.data_handler, self.datasets.value)
         self.dataset = dataset
 
     def _request_plot_data(self, _):

--- a/edr_explorer/explorer.py
+++ b/edr_explorer/explorer.py
@@ -38,8 +38,16 @@ class EDRExplorer(param.Parameterized):
     cmap = param.String("viridis")
     alpha = param.Magnitude(0.85)
 
+    # Buttons.
     connect_button = widgets.Button(description="Connect")
     submit_button = widgets.Button(description="Submit", disabled=True)
+    dataset_button = widgets.Button(
+        description="Get Dataset",
+        disabled=True,
+        layout=widgets.Layout(top="-0.5rem")
+    )
+
+    # Lists and boxes aggregating multiple widgets.
     wlist = [coll, locations, datasets, start_time, end_time]  # Metadata widgets.
     pwlist = [pc_times, pc_params]  # Plot widgets.
     pchecklist = [use_colours, use_levels]
@@ -63,10 +71,16 @@ class EDRExplorer(param.Parameterized):
 
         super().__init__()
 
+        # Class properties.
         self._edr_interface = None
+        self._dataset = None
 
+        # Button click bindings.
         self.connect_button.on_click(self._load_collections)
         self.submit_button.on_click(self._request_plot_data)
+        self.dataset_button.on_click(self._get_dataset)
+
+        # Watches on widgets.
         self.coll.observe(self._populate_contents_callback, names='value')
         self.start_time.observe(self._filter_end_time, names='value')
         self.pc_times.observe(self._plot_change, names='value')
@@ -85,6 +99,19 @@ class EDRExplorer(param.Parameterized):
         self._edr_interface = value
 
     @property
+    def dataset(self):
+        """
+        A well-known Python data object containing all the data represented by the current state
+        of select widgets on the dashboard.
+
+        """
+        return self._dataset
+
+    @dataset.setter
+    def dataset(self, value):
+        self._dataset = value
+
+    @property
     def layout(self):
         """
         Construct a layout of `Panel` objects to produce the EDR explorer dashboard.
@@ -99,18 +126,20 @@ class EDRExplorer(param.Parameterized):
             EDR Server via the `.interface.EDRInterface` instance
 
         There are some extra elements too:
-          * the widgets column on the left contains two buttons - one to connect to the server
-            at the web address specified in the `Server` text field widget; and one to submit a
-            query to the EDR Server via the `.interface.EDRInterface` instance based on the values
-            set in the selector widgets
+          * the widgets column on the left contains three buttons:
+              * one to connect to the server at the URI specified in the `Server` text field widget,
+              * one to submit a query to the EDR Server via the `.interface.EDRInterface` instance
+                based on the values set in the selector widgets, and
+              * one to request and return to the user all the data referenced by the current state
+                of the dashboard's select widgets as a well-known Python data object (such as an Iris cube).
           * the widgets column on the left also contains two fields for displaying error messages
             when connecting to or retrieving data from the EDR Server. These are hidden by
             default and are made visible when there is a relevant error message to display. Once
             the error has been resolved the field will become hidden again.
           * the plot area on the right contains two plot control widgets to select specific data
-            from queries submitted to the EDR Server to show on the plot
+            from queries submitted to the EDR Server to show on the plot.
           * the plot areas on the right also contains two checkboxes to select whether or not to
-            show data on the plot rendered using colours and levels supplied in the query response
+            show data on the plot rendered using colours and levels supplied in the query response.
 
         """
         connect_row = pn.Row(
@@ -118,7 +147,8 @@ class EDRExplorer(param.Parameterized):
             self.connect_button
         )
         control_widgets = pn.Column(self.wbox, self.data_error_box)
-        control_row = pn.Row(control_widgets, self.submit_button, align=("end", "start"))
+        buttons = pn.Column(self.submit_button, self.dataset_button)
+        control_row = pn.Row(control_widgets, buttons, align=("end", "start"))
         plot_col = pn.Column(self.plot, self.pwbox)
         control_col = pn.Column(connect_row, control_row)
         return pn.Row(control_col, plot_col).servable()
@@ -263,6 +293,18 @@ class EDRExplorer(param.Parameterized):
             times = self.start_time.options
             sel_idx = times.index(start_time_selected)
             self.end_time.options = times[sel_idx:]
+
+    def _get_dataset(self, _):
+        """
+        Callback when the `get dataset` button is clicked.
+
+        Request from the EDR Server all data represented by the current states of
+        the select widgets and provide this data as a well-known Python data
+        object (such as an Iris Cube).
+
+        """
+        dataset = None
+        self.dataset = dataset
 
     def _request_plot_data(self, _):
         """

--- a/edr_explorer/interface.py
+++ b/edr_explorer/interface.py
@@ -268,8 +268,6 @@ class EDRInterface(object):
         )
         data_json = self._get_covjson(query_str)
         self.data_handler = DataHandler(data_json)
-        # self.data_handler = None
-        # self.errors = "DidntDataError"
 
     def query_items(self):
         """

--- a/edr_explorer/lookup.py
+++ b/edr_explorer/lookup.py
@@ -1,6 +1,9 @@
 import cartopy.crs as ccrs
 
 
+WGS84_EARTH_RADIUS = 6371229
+
+
 HORIZONTAL_AXES_LOOKUP = {
     "x": [
         "x,"
@@ -44,12 +47,13 @@ CRS_LOOKUP = {
 
 TRS_LOOKUP = {
     "Gregorian Calendar": "gregorian",
+    "Gregorian": "gregorian",
 }
 
 
 UNITS_LOOKUP = {
-    ccrs.PlateCarree(): "degrees",
-    ccrs.Mercator(): "m",
+    "GeogCS": "degrees",
+    "Mercator": "m",
 }
 
 

--- a/edr_explorer/lookup.py
+++ b/edr_explorer/lookup.py
@@ -1,6 +1,41 @@
 import cartopy.crs as ccrs
 
 
+HORIZONTAL_AXES_LOOKUP = {
+    "x": [
+        "x,"
+        "longitude",
+        "projection_x_coord",
+    ],
+    "y": [
+        "y",
+        "latitude",
+        "projection_y_coord",
+    ],
+}
+
+
+SELECTION_AXES_LOOKUP = {
+    "z": [
+        "z",
+        "height",
+        "height_level",
+        "pressure_level",
+    ],
+    "t": [
+        "t",
+        "time",
+        "forecast_reference_time",
+        "forecast_period",
+    ],
+    "e": [
+        "e",
+        "ensemble_member",
+        "realization",
+    ],
+}
+
+
 CRS_LOOKUP = {
     "WGS_1984": ccrs.PlateCarree(),
     "GeographicCRS": ccrs.PlateCarree(),

--- a/edr_explorer/lookup.py
+++ b/edr_explorer/lookup.py
@@ -45,3 +45,15 @@ CRS_LOOKUP = {
 TRS_LOOKUP = {
     "Gregorian Calendar": "gregorian",
 }
+
+
+UNITS_LOOKUP = {
+    ccrs.PlateCarree(): "degrees",
+    ccrs.Mercator(): "m",
+}
+
+
+AXES_ORDER = ["e", "t", "z", "y", "x"]
+
+
+ISO_DATE_FMT_STR = "%Y-%m-%dT%H:%MZ"


### PR DESCRIPTION
Build the dataset that contains all of the data described by the current data query to the EDR Server made by the dashboard on clicking the `Get Dataset` button. The dataset is currently accessible only as a public attribute on the dashboard; ideally clicking the button will also add a code cell to the notebook that contains the code sufficient to access this dataset.

Fixes #19.